### PR TITLE
fix: Add Content-Type header to /metrics endpoint

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -427,7 +427,10 @@ async fn main() {
                 let metrics = metrics.clone();
                 async move {
                     let resp = match req.uri().path() {
-                        "/metrics" => Response::new(Full::new(Bytes::from(metrics.encode()))),
+                        "/metrics" => Response::builder()
+                            .header("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+                            .body(Full::new(Bytes::from(metrics.encode())))
+                            .unwrap(),
                         "/health" => Response::new(Full::new(Bytes::from("ok"))),
                         _ => Response::builder()
                             .status(StatusCode::NOT_FOUND)


### PR DESCRIPTION
## Summary
- Adds proper `Content-Type: text/plain; version=0.0.4` header to metrics endpoint
- Fixes Prometheus error: 'non-compliant scrape target sending blank Content-Type'

## Test
```bash
curl -sv http://railway-exporter-rs.railway.internal:8080/metrics 2>&1 | grep Content-Type
```